### PR TITLE
Add weekday names and degrees to dailies forecasts

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -77,11 +77,17 @@ class WeatherGetter {
   setBoxThree(weatherInfo) {
 
     let hoursOnly = (time) => {
-      let dateTime = new Date (time * 1000)
-      let newTime = (dateTime.toString().split(" "))[4]
-      let [hours, minutes] = newTime.split(":")
-      let standardTime = hours > 12 ? `${hours - 12}:${minutes}pm` : `${hours}:${minutes}am`
-      return `${standardTime}`
+      let dateTime = new Date (time * 1000);
+      let newTime = (dateTime.toString().split(" "))[4];
+      let [hours, minutes] = newTime.split(":");
+      let standardTime = hours > 12 ? `${hours - 12}:${minutes}pm` : `${hours}:${minutes}am`;
+      return `${standardTime}`;
+    }
+
+    let dayOnly = (time) => {
+      let dateTime = new Date (time * 1000);
+      let newTime = (dateTime.toString().split(" ") [0])
+      return (newTime)
     }
 
     let hourlyDivs = weatherInfo.hourlies.slice(0, 8).map(function(hourly) {
@@ -94,13 +100,16 @@ class WeatherGetter {
     });
 
     let dailyDivs = weatherInfo.dailies.slice(0, 5).map(function(daily) {
+      if(daily.precipType === undefined) {
+        daily.precipType = "none"};
+
       return (`
       <div class="daily">
-        <div class="daily-element">${daily.time}</div>
+        <div class="daily-element">${dayOnly(daily.time)}</div>
         <div class="daily-element"><p>${daily.icon}</p><p class="daily-summary">${daily.summary}</p></div>
         <div class="daily-element"><p>${daily.precipType}</p><p>${Math.round(daily.precipProbability * 100)}%</p></div>
-        <div class="daily-element">${daily.temperatureHigh}</div>
-        <div class="daily-element">${daily.temperatureLow}</div>
+        <div class="daily-element">${daily.temperatureHigh + '&deg'}</div>
+        <div class="daily-element">${daily.temperatureLow + '&deg'}</div>
       </div>
       `)
     });


### PR DESCRIPTION
#### Pivotal URL or Waffle Card number:
n/a (refactor)

#### What does this PR do?
adds weekday names and degrees symbols to dailies forecasts.

#### Where should the reviewer start?
in the js function: setBoxThree

#### Any additional context you want to provide?

#### Screenshots (if appropriate)
